### PR TITLE
Add an SSE 4.2 hotpath using the crc extensions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ no additional code.
 To create a hashmap call the `hashmap_create` function:
 
 ```c
-const unsigned initial_size = 4;
+const unsigned initial_size = 2;
 struct hashmap_s hashmap;
 if (0 != hashmap_create(initial_size, &hashmap)) {
   // error!
@@ -40,7 +40,8 @@ if (0 != hashmap_create(initial_size, &hashmap)) {
 ```
 
 The `initial_size` parameter only sets the initial size of the hashmap - which
-can grow if multiple keys hit the same hash entry.
+can grow if multiple keys hit the same hash entry. The initial size must be a
+power of two, and creation will fail if it is not.
 
 ### Put Something in a Hashmap
 
@@ -144,33 +145,6 @@ function:
 ```c
 hashmap_destroy(&hashmap);
 ```
-
-## CRC32 Function
-
-The implementation here was originally done by Gary S. Brown in 1986, who let
-the code or tables extracted from it without restriction.
-
-First, the polynomial itself and its table of feedback terms.  The polynomial is
-`X^32+X^26+X^23+X^22+X^16+X^12+X^11+X^10+X^8+X^7+X^5+X^4+X^2+X^1+X^0`. Note that
-we take it "backwards" and put the highest-order term in the lowest-order bit.
-The `X^32` term is "implied"; the LSB is the `X^31` term, etc. The `X^0` term
-(usually shown as "+1") results in the MSB being 1. Note that the usual hardware
-shift register implementation, which is what we're using (we're merely
-optimizing it by doing eight-bit chunks at a time) shifts bits into the
-lowest-order term. In our implementation, that means shifting towards the right. 
-Why do we do it this way? Because the calculated CRC must be transmitted in
-order from highest-order term to lowest-order term. UARTs transmit characters in
-order from LSB to MSB. By storing the CRC this way, we hand it to the UART in
-the order low-byte to high-byte; the UART sends each low-bit to hight-bit; and
-the result is transmission bit by bit from highest- to lowest-order term without
-requiring any bit shuffling on our part. Reception works similarly. The feedback
-terms table consists of 256, 32-bit entries. Notes: The table can be generated
-at runtime if desired; code to do so is shown later. It might not be obvious,
-but the feedback terms simply represent the results of eight shift/xor
-operations for all combinations of data and CRC register values. The values must
-be right-shifted by eight bits by the "updcrc" logic; the shift must be unsigned
-(bring in zeroes). On some hardware you could probably optimize the shift in
-assembler by using byte-swap instructions.
 
 ## Code Ownership
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -29,11 +29,6 @@ cmake_minimum_required(VERSION 3.1.3)
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/../)
 
 if("${CMAKE_C_COMPILER_ID}" STREQUAL "GNU")
-  list(FIND CMAKE_C_COMPILE_FEATURES c_std_11 IDX)
-  if (${IDX} GREATER -1)
-    set_source_files_properties(type_printers.c PROPERTIES
-      COMPILE_FLAGS "-std=gnu11")
-  endif()
   set_source_files_properties(main.c test.c PROPERTIES
     COMPILE_FLAGS "-Wall -Wextra -Werror -std=gnu89"
   )
@@ -81,10 +76,27 @@ else()
   message(WARNING "Unknown compiler '${CMAKE_C_COMPILER_ID}'!")
 endif()
 
+if("${CMAKE_C_COMPILER_ID}" STREQUAL "GNU")
+  set_source_files_properties(test_sse42.c PROPERTIES
+    COMPILE_FLAGS "-Wall -Wextra -Werror -std=gnu89 -msse4.2"
+  )
+elseif("${CMAKE_C_COMPILER_ID}" STREQUAL "Clang")
+  set_source_files_properties(test_sse42.c PROPERTIES
+    COMPILE_FLAGS "-Wall -Wextra -Weverything -Werror -std=gnu89 -msse4.2"
+  )
+elseif("${CMAKE_C_COMPILER_ID}" STREQUAL "MSVC")
+  set_source_files_properties(test_sse42.c PROPERTIES
+    COMPILE_FLAGS "/Wall /WX /wd4514 /wd5045 /arch:AVX"
+  )
+else()
+  message(WARNING "Unknown compiler '${CMAKE_C_COMPILER_ID}'!")
+endif()
+
 add_executable(hashmap_test
   ../hashmap.h
   main.c
   test.c
+  test_sse42.c
   test.cpp
   test11.cpp
 )

--- a/test/test.c
+++ b/test/test.c
@@ -7,6 +7,11 @@ UTEST(c, create) {
   hashmap_destroy(&hashmap);
 }
 
+UTEST(c, create_not_power_of_two) {
+  struct hashmap_s hashmap;
+  ASSERT_EQ(1, hashmap_create(3, &hashmap));
+}
+
 static int set_context(void *const context, void *const element) {
   *(int *)context = *(int *)element;
   return 1;
@@ -133,4 +138,11 @@ UTEST(c, num_entries) {
   ASSERT_EQ(0, hashmap_remove(&hashmap, "foo", (unsigned)strlen("foo")));
   ASSERT_EQ(0u, hashmap_num_entries(&hashmap));
   hashmap_destroy(&hashmap);
+}
+
+// Define a global function that uses the crc32 helper so we can test it against
+// the SSE 4.2 version.
+unsigned crc32_scalar(const char *const s, const unsigned len);
+unsigned crc32_scalar(const char *const s, const unsigned len) {
+  return hashmap_crc32_helper(s, len);
 }

--- a/test/test11.cpp
+++ b/test/test11.cpp
@@ -16,6 +16,11 @@ UTEST(cpp11, create) {
   hashmap_destroy(&hashmap);
 }
 
+UTEST(cpp11, create_not_power_of_two) {
+  struct hashmap_s hashmap;
+  ASSERT_EQ(1, hashmap_create(3, &hashmap));
+}
+
 static int NOTHROW set_context(void *const context,
                                void *const element) NOEXCEPT {
   *static_cast<int *>(context) = *static_cast<int *>(element);


### PR DESCRIPTION
SSE 4.2 has an awesome set of x86 extensions for CRC functions. This commit makes use of them if hashmap.h was built with a compiler that supports SSE 4.2 or above. To ensure that users could mix code that used the SSE 4.2 crc functions and the scalar fallback code in multiple compilation units of their executable, the fallback CRC function was changed to mimic the polynomial that Intel uses for the CRC functions.

I also fixed a bug with the `initial_size` of `hashmap_create` it is expected to be a power of 2 value, and that wasn't recorded previously. Now the create function will return an error if the size isn't a power of two.