### PR TITLE
Add hashmap_create_ex, and start to simplify the API.

### DIFF
--- a/test/test.c
+++ b/test/test.c
@@ -9,12 +9,16 @@ UTEST(c, create) {
 
 UTEST(c, create_zero) {
   struct hashmap_s hashmap;
-  ASSERT_EQ(1, hashmap_create(0, &hashmap));
+  ASSERT_EQ(0, hashmap_create(0, &hashmap));
+  ASSERT_LT(0u, hashmap_capacity(&hashmap));
+  hashmap_destroy(&hashmap);
 }
 
 UTEST(c, create_not_power_of_two) {
   struct hashmap_s hashmap;
-  ASSERT_EQ(1, hashmap_create(3, &hashmap));
+  ASSERT_EQ(0, hashmap_create(3, &hashmap));
+  ASSERT_LE(3u, hashmap_capacity(&hashmap));
+  hashmap_destroy(&hashmap);
 }
 
 static int set_context(void *const context, void *const element) {
@@ -200,13 +204,6 @@ UTEST(c, remove_all) {
   ASSERT_EQ(26, total);
   ASSERT_EQ(0u, hashmap_num_entries(&hashmap));
   hashmap_destroy(&hashmap);
-}
-
-// Define a global function that uses the crc32 helper so we can test it against
-// the SSE 4.2 version.
-unsigned crc32_scalar(const char *const s, const unsigned len);
-unsigned crc32_scalar(const char *const s, const unsigned len) {
-  return hashmap_crc32_helper(s, len);
 }
 
 UTEST(c, hash_conflict) {

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -15,12 +15,16 @@ UTEST(cpp, create) {
 
 UTEST(cpp, create_zero) {
   struct hashmap_s hashmap;
-  ASSERT_EQ(1, hashmap_create(0, &hashmap));
+  ASSERT_EQ(0, hashmap_create(0, &hashmap));
+  ASSERT_LT(0u, hashmap_capacity(&hashmap));
+  hashmap_destroy(&hashmap);
 }
 
 UTEST(cpp, create_not_power_of_two) {
   struct hashmap_s hashmap;
-  ASSERT_EQ(1, hashmap_create(3, &hashmap));
+  ASSERT_EQ(0, hashmap_create(3, &hashmap));
+  ASSERT_LE(3u, hashmap_capacity(&hashmap));
+  hashmap_destroy(&hashmap);
 }
 
 static int NOTHROW set_context(void *const context, void *const element) {
@@ -82,8 +86,8 @@ UTEST(cpp, remove_and_return_key) {
 
   /* Use a new string here so that we definitely have a different pointer key
    * being provided. */
-  ASSERT_EQ(key, hashmap_remove_and_return_key(
-                     &hashmap, "foo", static_cast<unsigned>(strlen("foo"))));
+  ASSERT_EQ(key, static_cast<const char *>(hashmap_remove_and_return_key(
+                     &hashmap, "foo", static_cast<unsigned>(strlen("foo")))));
   hashmap_destroy(&hashmap);
 }
 

--- a/test/test11.cpp
+++ b/test/test11.cpp
@@ -22,12 +22,16 @@ UTEST(cpp11, create) {
 
 UTEST(cpp11, create_zero) {
   struct hashmap_s hashmap;
-  ASSERT_EQ(1, hashmap_create(0, &hashmap));
+  ASSERT_EQ(0, hashmap_create(0, &hashmap));
+  ASSERT_LT(0u, hashmap_capacity(&hashmap));
+  hashmap_destroy(&hashmap);
 }
 
 UTEST(cpp11, create_not_power_of_two) {
   struct hashmap_s hashmap;
-  ASSERT_EQ(1, hashmap_create(3, &hashmap));
+  ASSERT_EQ(0, hashmap_create(3, &hashmap));
+  ASSERT_LE(3u, hashmap_capacity(&hashmap));
+  hashmap_destroy(&hashmap);
 }
 
 static int NOTHROW set_context(void *const context,

--- a/test/test_sse42.c
+++ b/test/test_sse42.c
@@ -11,12 +11,16 @@ UTEST(c_sse42, create) {
 
 UTEST(c_sse42, create_zero) {
   struct hashmap_s hashmap;
-  ASSERT_EQ(1, hashmap_create(0, &hashmap));
+  ASSERT_EQ(0, hashmap_create(0, &hashmap));
+  ASSERT_LT(0u, hashmap_capacity(&hashmap));
+  hashmap_destroy(&hashmap);
 }
 
 UTEST(c_sse42, create_not_power_of_two) {
   struct hashmap_s hashmap;
-  ASSERT_EQ(1, hashmap_create(3, &hashmap));
+  ASSERT_EQ(0, hashmap_create(3, &hashmap));
+  ASSERT_LE(3u, hashmap_capacity(&hashmap));
+  hashmap_destroy(&hashmap);
 }
 
 static int set_context(void *const context, void *const element) {
@@ -163,18 +167,6 @@ UTEST(c_sse42, num_entries) {
   ASSERT_EQ(0, hashmap_remove(&hashmap, "foo", (unsigned)strlen("foo")));
   ASSERT_EQ(0u, hashmap_num_entries(&hashmap));
   hashmap_destroy(&hashmap);
-}
-
-extern unsigned crc32_scalar(const char *const s, const unsigned len);
-
-UTEST(c_sse42, crc32_matches) {
-  unsigned index;
-
-  for (index = 0; index <= 0xff; index++) {
-    const char c = (char)index;
-
-    ASSERT_EQ(crc32_scalar(&c, 1), hashmap_crc32_helper(&c, 1));
-  }
 }
 
 UTEST(c_sse42, hash_conflict) {


### PR DESCRIPTION
I've done far too many little things in here, but:

- I used Fibonacci Hashing instead of plain old pow-2-modulus to better shuffle up the keys as I mod down to the range.
- I added `hashmap_create_ex` which lets users specify a hashing algorithm to use instead of the default CRC32 one.
- I made it so that an initial capacity is just a hint that you need *at least* that many elements, and we'll round up to the next pow-2 (or otherwise if I ever change the resizing algorithm).