### PR TITLE
Fixed key lengths in benchmark and linked math library

### DIFF
--- a/bench/CMakeLists.txt
+++ b/bench/CMakeLists.txt
@@ -34,6 +34,11 @@ add_executable(hashmap_bench
   sse42.c
 )
 
+find_library(MATH_LIBRARY m)
+if(MATH_LIBRARY)
+    target_link_libraries(hashmap_bench PUBLIC ${MATH_LIBRARY})
+endif()
+
 if (NOT "${CMAKE_SYSTEM_PROCESSOR}" STREQUAL "arm64")
   if("${CMAKE_C_COMPILER_ID}" STREQUAL "GNU")
     set_source_files_properties(sse42.c PROPERTIES

--- a/bench/sse42.c
+++ b/bench/sse42.c
@@ -42,7 +42,7 @@ struct put_small_keys_sse42 {
 
 UBENCH_F_SETUP(put_small_keys_sse42) {
   const unsigned max_keys = 1024 * 1024;
-  const unsigned key_len = 8;
+  const unsigned key_len = 8+1;
   char *const keys = malloc(max_keys * key_len);
   unsigned i;
 
@@ -95,7 +95,7 @@ struct put_large_keys_sse42 {
 
 UBENCH_F_SETUP(put_large_keys_sse42) {
   const unsigned max_keys = 1024 * 1024;
-  const unsigned key_len = 1024;
+  const unsigned key_len = 1024+1;
   char *const keys = malloc(max_keys * key_len);
   unsigned i;
 
@@ -133,7 +133,7 @@ struct get_small_keys_sse42 {
 
 UBENCH_F_SETUP(get_small_keys_sse42) {
   const unsigned max_keys = 1024 * 1024;
-  const unsigned key_len = 8;
+  const unsigned key_len = 8+1;
   char *const keys = malloc(max_keys * key_len);
   unsigned i;
   struct hashmap_s hashmap;
@@ -184,7 +184,7 @@ struct get_large_keys_sse42 {
 
 UBENCH_F_SETUP(get_large_keys_sse42) {
   const unsigned max_keys = 1024 * 1024;
-  const unsigned key_len = 1024;
+  const unsigned key_len = 1024+1;
   char *const keys = malloc(max_keys * key_len);
   unsigned i;
   struct hashmap_s hashmap;


### PR DESCRIPTION
When trying to build the benchmarks I found that the compiler generated the following error:
```
/home/ar/sources/hashmap.h/bench/sse42.c:50:50: error: ‘snprintf’ output truncated before the last format character [-Werror=format-truncation=]
   50 |     snprintf(keys + (i * key_len), key_len, "%08x", i);
      |                                                  ^
/home/ar/sources/hashmap.h/bench/sse42.c:50:5: note: ‘snprintf’ output 9 bytes into a destination of size 8
   50 |     snprintf(keys + (i * key_len), key_len, "%08x", i);
      |     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
cc1: all warnings being treated as errors
```

I fixed this by adding space for the null terminator by increasing every key_len by 1.

I also found undefined references to 'sqrt' on my linux machine so I added a check that links the math library if it is available.